### PR TITLE
Add hdfs storage

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -10,3 +10,7 @@ tags: []
 provides:
   namenode:
     interface: dfs-slave
+storage:
+  hdfs:
+    type: filesystem
+    location: /data


### PR DESCRIPTION
This PR introduces juju storage support for the layer-hadoop-datanode.

Fixes: https://github.com/juju-solutions/bigtop/issues/53

* add storage stanza to metadata.yaml